### PR TITLE
.github/workflows: use ubuntu-latest

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on: "linux-x64-ubuntu-latest-64-core"
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@master
 


### PR DESCRIPTION
"linux-x64-ubuntu-latest-64-core" queue times are O(hours or days) - not usable.