### PR TITLE
readme: add pkg.go.dev badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Join if you want! https://discord.gg/R82YagTASx
 
 ## Development
 
+[![Go Reference](https://pkg.go.dev/badge/sketch.dev.svg)](https://pkg.go.dev/sketch.dev)
+
 See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Open Source


### PR DESCRIPTION
Since the go.mod uses a custom URL, it's easier to provide the badge for new users to direct to the right URL.