### PR TITLE
dockerimg: improve inner sketch binary building for development

### DIFF
--- a/dockerimg/dockerimg.go
+++ b/dockerimg/dockerimg.go
@@ -508,6 +508,21 @@ func createDockerContainer(ctx context.Context, cntrName, hostPort, relPath, img
 }
 
 func buildLinuxSketchBin(ctx context.Context) (string, error) {
+	// Change to directory containing dockerimg.go for module detection
+	_, codeFile, _, _ := runtime.Caller(0)
+	codeDir := filepath.Dir(codeFile)
+	if currentDir, err := os.Getwd(); err != nil {
+		slog.WarnContext(ctx, "could not get current directory", "err", err)
+	} else {
+		if err := os.Chdir(codeDir); err != nil {
+			slog.WarnContext(ctx, "could not change to code directory for module check", "err", err)
+		} else {
+			defer func() {
+				_ = os.Chdir(currentDir)
+			}()
+		}
+	}
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fixes an issue where local changes to sketch codebase weren't properly
reflected in the Docker container. Previously when using `go run ./cmd/sketch`,
the module detection would report "command-line-arguments" instead of
"sketch.dev", causing the system to use the latest published version
instead of local changes.

This change adds detection for when Sketch is running from a source checkout
even with `go run`, and ensures the container uses the local source for the
inner sketch binary when in development mode. Production installation
remains unchanged.

Co-Authored-By: sketch <hello@sketch.dev>
