### PR TITLE
Adjust bash default timeout

### DIFF
--- a/claudetool/bash.go
+++ b/claudetool/bash.go
@@ -63,7 +63,7 @@ starting a server to test something. Be sure to kill the process group when done
     },
     "timeout": {
       "type": "string",
-      "description": "Timeout as a Go duration string, defaults to 10s if background is false; 10m if background is true"
+      "description": "Timeout as a Go duration string, defaults to 40s if background is false; 10m if background is true"
     },
     "background": {
       "type": "boolean",
@@ -98,7 +98,7 @@ func (i *bashInput) timeout() time.Duration {
 	if i.Background {
 		return 10 * time.Minute
 	} else {
-		return 10 * time.Second
+		return 40 * time.Second
 	}
 }
 

--- a/claudetool/bash_test.go
+++ b/claudetool/bash_test.go
@@ -394,7 +394,7 @@ func TestBashTimeout(t *testing.T) {
 			Background: false,
 		}
 		fgTimeout := foreground.timeout()
-		expectedFg := 10 * time.Second
+		expectedFg := 40 * time.Second
 		if fgTimeout != expectedFg {
 			t.Errorf("Expected foreground default timeout to be %v, got %v", expectedFg, fgTimeout)
 		}

--- a/loop/testdata/agent_loop.httprr
+++ b/loop/testdata/agent_loop.httprr
@@ -40,7 +40,7 @@ Content-Type: application/json
      },
      "timeout": {
       "type": "string",
-      "description": "Timeout as a Go duration string, defaults to 10s if background is false; 10m if background is true"
+      "description": "Timeout as a Go duration string, defaults to 40s if background is false; 10m if background is true"
      },
      "background": {
       "type": "boolean",


### PR DESCRIPTION
## Summary
- bump default bash timeout to 40s
- update tests and docs accordingly

## Testing
- `go generate ./...` *(fails: no route to host)*
- `go test ./...` *(fails: no route to host)*
