### PR TITLE
github: prevent discord webhook from running on forks

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -9,6 +9,7 @@ permissions: read-all
 jobs:
   notify-discord:
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Fix Discord notification workflow triggering on forked repositories where secrets are unavailable and notifications are unnecessary for contributors.

Problem Analysis:
The Discord webhook workflow was configured to run on all repositories, including forks, where the DISCORD_WEBHOOK_FOR_COMMITS secret would be unavailable. This caused workflow failures and attempted notifications from forks that serve no purpose for the main project's Discord channel.

Implementation Changes:
- Added if: github.event.repository.fork == false condition to notify-discord job
- Prevents execution on forked repositories while maintaining functionality on origin
- Uses GitHub's built-in repository metadata for reliable fork detection

Benefits:
- Eliminates workflow failures on forks due to missing secrets
- Reduces unnecessary workflow runs on contributor forks
- Maintains proper Discord notifications only for the main repository
- Clean workflow execution without configuration changes required

This ensures Discord notifications only occur for the main repository while preventing errors and resource waste on community forks.


Change-ID: s5a155846902dd30fk