### PR TITLE
webui: fix copy button functionality for new branch creation

### DIFF
--- a/webui/src/web-components/sketch-timeline-message.ts
+++ b/webui/src/web-components/sketch-timeline-message.ts
@@ -1477,7 +1477,10 @@ export class SketchTimelineMessage extends LitElement {
                                           )}
                                         >${commit.pushed_branch}</span
                                       >
-                                      <span class="copy-icon">
+                                      <span class="copy-icon" @click=${(e) => {
+                                        e.stopPropagation();
+                                        this.copyToClipboard(commit.pushed_branch, e);
+                                      }}>
                                         <svg
                                           xmlns="http://www.w3.org/2000/svg"
                                           width="14"


### PR DESCRIPTION
Add click handler to copy icon in commit branch containers to enable copying branch names by clicking the icon, not just the branch name text.


Change-ID: saee9afbb466904efk