### PR TITLE
all: update shebangs for more portability

### DIFF
--- a/bin/run-formatters.sh
+++ b/bin/run-formatters.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Script to run formatters for both Go and webui files

--- a/build/clean.sh
+++ b/build/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 rm -f sketch

--- a/build/innie.sh
+++ b/build/innie.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS:-}" -tags=innie -o embedded/sketch-linux/sketch-linux-amd64 ./cmd/sketch &

--- a/build/outie.sh
+++ b/build/outie.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Note: This incantation is duplicated in .goreleaser.yml; please keep them in sync.

--- a/build/webui.sh
+++ b/build/webui.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Use a content-based hash of the webui dir to avoid unnecessary rebuilds.

--- a/claudetool/codereview/update_tests.sh
+++ b/claudetool/codereview/update_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CURRENT_DIR=$(pwd)

--- a/dockerimg/post-receive.sh
+++ b/dockerimg/post-receive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Post-receive hook for sketch git http server
 # Sets upstream tracking branch for sketch branches
 

--- a/dockerimg/pre-receive.sh
+++ b/dockerimg/pre-receive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Pre-receive hook for sketch git http server
 # Handles refs/remotes/origin/Y pushes by forwarding them to origin/Y
 

--- a/loop/update_tests.sh
+++ b/loop/update_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CURRENT_DIR=$(pwd)


### PR DESCRIPTION
NixOS by default doesn't ship with /bin/bash, rather /usr/bin/env bash is the way to get the right bash.

This caused two issues on NixOS:

1. The `push` button on the web interface would fail with ` ! [remote rejected] <commit> -> <branch> (pre-receive hook declined)`
2. `make` would result in an error

On the host side, for 1 you could see `fatal: cannot exec '/tmp/sketch-git-hooks-3993344797/pre-receive': No such file or directory`, and for 2, you could similarly see `make: ./build/webui.sh: No such file or directory`

This fixes both of those errors by updating to the expected NixOS shebangs.