### PR TITLE
ll/gem: support Gemini 3 pro preview

### DIFF
--- a/cmd/sketch/main.go
+++ b/cmd/sketch/main.go
@@ -130,7 +130,7 @@ func run() error {
 		fmt.Println("- claude (default, Claude 4.5 Sonnet)")
 		fmt.Println("- opus (Claude 4.5 Opus)")
 		fmt.Println("- sonnet (Claude 4.5 Sonnet)")
-		fmt.Println("- gemini (Google Gemini 2.5 Pro)")
+		fmt.Println("- gemini (Google Gemini 3 Pro)")
 		fmt.Println("- qwen (Qwen3-Coder)")
 		fmt.Println("- glm (Zai GLM4.5)")
 		for _, name := range oai.ListModels() {

--- a/llm/gem/gem.go
+++ b/llm/gem/gem.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	DefaultModel    = "gemini-2.5-pro-preview-03-25"
+	DefaultModel    = "gemini-3-pro-preview"
 	GeminiAPIKeyEnv = "GEMINI_API_KEY"
 )
 
@@ -447,6 +447,8 @@ func (s *Service) TokenContextWindow() int {
 
 	// Gemini models generally have large context windows
 	switch model {
+	case "gemini-3-pro-preview":
+		return 1000000 // 1M tokens for Gemini 3 Pro
 	case "gemini-2.5-pro-preview-03-25":
 		return 1000000 // 1M tokens for Gemini 2.5 Pro
 	case "gemini-2.0-flash-exp":

--- a/llm/gem/gem.go
+++ b/llm/gem/gem.go
@@ -218,6 +218,7 @@ func (s *Service) buildGeminiRequest(req *llm.Request) (*gemini.Request, error) 
 						Name: c.ToolName,
 						Args: args,
 					},
+					ThoughtSignature: c.Signature,
 				})
 			case llm.ContentTypeToolResult:
 				// Tool result becomes a function response
@@ -346,6 +347,7 @@ func convertGeminiResponseToContent(res *gemini.Response) []llm.Content {
 				Type:      llm.ContentTypeToolUse,
 				ToolName:  part.FunctionCall.Name,
 				ToolInput: json.RawMessage(args),
+				Signature: part.ThoughtSignature,
 			})
 
 			slog.DebugContext(context.Background(), "gemini_tool_call",

--- a/llm/gem/gemini/gemini.go
+++ b/llm/gem/gemini/gemini.go
@@ -47,6 +47,7 @@ type Part struct {
 	FunctionResponse    *FunctionResponse    `json:"functionResponse,omitempty"`
 	ExecutableCode      *ExecutableCode      `json:"executableCode,omitempty"`
 	CodeExecutionResult *CodeExecutionResult `json:"codeExecutionResult,omitempty"`
+	ThoughtSignature    string               `json:"thoughtSignature,omitempty"`
 	// TODO inlineData
 	// TODO fileData
 }

--- a/llm/oai/oai.go
+++ b/llm/oai/oai.go
@@ -122,6 +122,13 @@ var (
 		APIKeyEnv: GeminiAPIKeyEnv,
 	}
 
+	Gemini3Pro = Model{
+		UserName:  "gemini-pro-3",
+		ModelName: "gemini-3-pro-preview",
+		URL:       GeminiURL,
+		APIKeyEnv: GeminiAPIKeyEnv,
+	}
+
 	TogetherDeepseekV3 = Model{
 		UserName:  "together-deepseek-v3",
 		ModelName: "deepseek-ai/DeepSeek-V3",
@@ -311,6 +318,7 @@ var ModelsRegistry = []Model{
 	O4Mini,
 	Gemini25Flash,
 	Gemini25Pro,
+	Gemini3Pro,
 	TogetherDeepseekV3,
 	TogetherDeepseekR1,
 	TogetherLlama4Maverick,


### PR DESCRIPTION
# Changes

Just volunteering this because I found it useful — this PR updates Gemini model support:

+ Adds support for the gemini-3-pro-preview model, which requires echoing a `thoughtSignature` for tool calls
+ Makes gemini-3-pro-preview the default gemini model over gemini-2.5-pro-preview-03-25

# Motivation

It _looks_ like the gemini-1.5-pro model (still the Gemini default in the latest tagged release of Sketch) is no longer available through the API you use:

```
gemini: API error after 4 attempts: GenerateContent: HTTP status: 404, {
  "error": {
    "code": 404,
    "message": "models/gemini-1.5-pro is not found for API version v1beta, or is not supported for generateContent. Call ListModels to see the list of available models and their supported methods.",
    "status": "NOT_FOUND"
  }
}
```

And indeed it isn't included in the hosted list:

```console
$ curl https://generativelanguage.googleapis.com/v1beta/models\?key\=$GEMINI_API_KEY | grep "gemini-1.5"
# ... empty.
```

I'm happy to update this PR to remove references to 1.5 if you like.